### PR TITLE
Gracefully handle missing input files

### DIFF
--- a/sql_siddha/cli.py
+++ b/sql_siddha/cli.py
@@ -16,7 +16,8 @@ def _read_input(path: Optional[str]) -> str:
         try:
             return Path(path).read_text()
         except FileNotFoundError:
-            raise FileNotFoundError(f"File not found: {path}")
+            print(f"File not found: {path}", file=sys.stderr)
+            raise SystemExit(1)
     return ""
 
 
@@ -36,21 +37,15 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "format":
-        try:
-            sql = _read_input(args.path)
-        except FileNotFoundError as exc:
-            print(exc, file=sys.stderr)
-            return 1
+        sql = _read_input(args.path)
         formatted = format_sql(sql, dialect=args.dialect)
         output_path = args.output or args.path
-        Path(output_path).write_text(formatted + ("\n" if not formatted.endswith("\n") else ""))
+        Path(output_path).write_text(
+            formatted + ("\n" if not formatted.endswith("\n") else "")
+        )
         return 0
     else:  # lint
-        try:
-            sql = _read_input(args.path)
-        except FileNotFoundError as exc:
-            print(exc, file=sys.stderr)
-            return 1
+        sql = _read_input(args.path)
         messages = lint_sql(sql, dialect=args.dialect)
         for msg in messages:
             print(msg)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -42,7 +42,13 @@ def test_cli_lint_multiple_statements(tmp_path):
     assert "Keyword 'select' should be uppercase" in stdout
 
 
-def test_cli_missing_file():
+def test_cli_lint_missing_file():
     result = run_cli("lint", "missing.sql")
+    assert result.returncode == 1
+    assert "File not found" in result.stderr
+
+
+def test_cli_format_missing_file():
+    result = run_cli("format", "missing.sql")
     assert result.returncode == 1
     assert "File not found" in result.stderr


### PR DESCRIPTION
## Summary
- Print a clear message and exit with status 1 when an input file is missing
- Avoid duplicated file-reading error handling in CLI
- Test missing-file behaviour for both `lint` and `format` commands

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b49d9e0120832faaeb223a9d218f80