### PR TITLE
Improve MERGE formatting and add casing options

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,10 @@ sql-siddha lint path/to/query.sql
 ```
 
 Both commands support a ``--dialect`` option which defaults to ``ansi``.
+
+The formatter also accepts ``--keyword-case`` and ``--identifier-case`` flags to
+control the casing of SQL keywords and non-keyword identifiers respectively:
+
+```bash
+sql-siddha format path/to/query.sql --keyword-case lower --identifier-case upper
+```

--- a/sql_siddha/cli.py
+++ b/sql_siddha/cli.py
@@ -29,6 +29,18 @@ def main(argv: list[str] | None = None) -> int:
     p_format.add_argument("path", help="Path to SQL file")
     p_format.add_argument("--dialect", default="ansi", help="SQL dialect")
     p_format.add_argument("-o", "--output", help="Output file; default overwrites input")
+    p_format.add_argument(
+        "--keyword-case",
+        choices=["upper", "lower"],
+        default="upper",
+        help="Case for SQL keywords",
+    )
+    p_format.add_argument(
+        "--identifier-case",
+        choices=["upper", "lower"],
+        default=None,
+        help="Case for non-keyword identifiers",
+    )
 
     p_lint = sub.add_parser("lint", help="Lint SQL")
     p_lint.add_argument("path", help="Path to SQL file")
@@ -38,7 +50,12 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "format":
         sql = _read_input(args.path)
-        formatted = format_sql(sql, dialect=args.dialect)
+        formatted = format_sql(
+            sql,
+            dialect=args.dialect,
+            keyword_case=args.keyword_case,
+            identifier_case=args.identifier_case,
+        )
         output_path = args.output or args.path
         Path(output_path).write_text(
             formatted + ("\n" if not formatted.endswith("\n") else "")

--- a/sql_siddha/formatter.py
+++ b/sql_siddha/formatter.py
@@ -4,13 +4,89 @@ from __future__ import annotations
 
 from typing import Literal
 
+import re
 import sqlparse
 
 
 SUPPORTED_DIALECTS = {"ansi"}
 
 
-def format_sql(sql: str, dialect: Literal["ansi"] = "ansi") -> str:
+def _format_merge(
+    stmt: str,
+    *,
+    keyword_case: Literal["upper", "lower", None] = "upper",
+    identifier_case: Literal["upper", "lower", None] = None,
+) -> str:
+    """Custom formatter for MERGE statements.
+
+    ``sqlparse`` does not properly reindent MERGE statements. This helper uses a
+    simple regex-based approach to structure the statement into the expected
+    multi-line format and then applies the requested casing rules.
+    """
+
+    pattern = re.compile(
+        r"merge\s+into\s+(?P<target>.+?)\s+using\s+(?P<source>.+?)\s+on\s+(?P<on>.+?)\s+"
+        r"when\s+matched\s+then\s+update\s+set\s+(?P<set>.+?)\s+when\s+not\s+matched\s+"
+        r"then\s+insert\s*\((?P<cols>.+?)\)\s+values\s*\((?P<vals>.+?)\);?",
+        re.IGNORECASE | re.DOTALL,
+    )
+    m = pattern.match(stmt.strip())
+    if not m:
+        # Fallback to generic formatting if the pattern doesn't match
+        formatted = sqlparse.format(
+            stmt,
+            keyword_case=keyword_case,
+            identifier_case=identifier_case,
+            reindent=True,
+            strip_whitespace=True,
+        ).strip()
+        if not formatted.endswith(";"):
+            formatted = formatted.rstrip(";") + ";"
+        return formatted
+
+    target = m.group("target").strip()
+    source = m.group("source").strip()
+    on_cond = m.group("on").strip()
+    set_clause = m.group("set").strip()
+    cols = m.group("cols").replace("\n", " ").strip()
+    vals = m.group("vals").replace("\n", " ").strip()
+
+    formatted = (
+        "MERGE INTO "
+        + target
+        + "\nUSING "
+        + source
+        + "\n    ON "
+        + on_cond
+        + "\nWHEN MATCHED THEN\n    UPDATE\n    SET "
+        + set_clause
+        + "\nWHEN NOT MATCHED THEN\n    INSERT ("
+        + cols
+        + ")\n    VALUES ("
+        + vals
+        + ");"
+    )
+
+    # Apply casing without altering whitespace/indentation
+    formatted = sqlparse.format(
+        formatted,
+        keyword_case=keyword_case,
+        identifier_case=identifier_case,
+        reindent=False,
+        strip_whitespace=False,
+    ).strip()
+    if not formatted.endswith(";"):
+        formatted = formatted.rstrip(";") + ";"
+    return formatted
+
+
+def format_sql(
+    sql: str,
+    dialect: Literal["ansi"] = "ansi",
+    *,
+    keyword_case: Literal["upper", "lower", None] = "upper",
+    identifier_case: Literal["upper", "lower", None] = None,
+) -> str:
     """Return a formatted SQL string.
 
     Parameters
@@ -24,7 +100,7 @@ def format_sql(sql: str, dialect: Literal["ansi"] = "ansi") -> str:
     if dialect not in SUPPORTED_DIALECTS:
         raise NotImplementedError(f"Dialect '{dialect}' is not supported yet")
 
-    formatted_parts = []
+    formatted_parts: list[str] = []
 
     # Format each individual statement and preserve order
     for raw_stmt in sqlparse.split(sql):
@@ -32,14 +108,22 @@ def format_sql(sql: str, dialect: Literal["ansi"] = "ansi") -> str:
         if not stmt:
             continue
 
-        formatted = sqlparse.format(
-            stmt,
-            keyword_case="upper",
-            reindent=True,
-            strip_whitespace=True,
-        ).strip()
-        if not formatted.endswith(";"):
-            formatted = formatted.rstrip(";") + ";"
+        if stmt.lstrip().upper().startswith("MERGE"):
+            formatted = _format_merge(
+                stmt,
+                keyword_case=keyword_case,
+                identifier_case=identifier_case,
+            )
+        else:
+            formatted = sqlparse.format(
+                stmt,
+                keyword_case=keyword_case,
+                identifier_case=identifier_case,
+                reindent=True,
+                strip_whitespace=True,
+            ).strip()
+            if not formatted.endswith(";"):
+                formatted = formatted.rstrip(";") + ";"
         formatted_parts.append(formatted)
 
     return "\n".join(formatted_parts)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,6 +13,25 @@ def test_cli_format(tmp_path, capsys):
     assert captured.err == ""
 
 
+def test_cli_format_case_options(tmp_path):
+    path = tmp_path / "query.sql"
+    path.write_text("select id from users")
+    assert (
+        main(
+            [
+                "format",
+                str(path),
+                "--keyword-case",
+                "lower",
+                "--identifier-case",
+                "upper",
+            ]
+        )
+        == 0
+    )
+    assert path.read_text().strip() == "select ID\nfrom USERS;"
+
+
 def test_cli_lint_success(tmp_path, capsys):
     path = tmp_path / "query.sql"
     path.write_text("SELECT * FROM users;")
@@ -87,4 +106,3 @@ def test_cli_invalid_dialect_lint(tmp_path):
     path.write_text("select * from users")
     with pytest.raises(NotImplementedError):
         main(["lint", str(path), "--dialect", "invalid"])
-

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -13,7 +13,7 @@ from sql_siddha.formatter import format_sql
         ),
         (
             "merge into target t using source s on t.id = s.id when matched then update set col = s.col when not matched then insert (id, col) values (s.id, s.col);",
-            "MERGE INTO target t USING SOURCE s ON t.id = s.id WHEN matched THEN\nUPDATE\nSET col = s.col WHEN NOT matched THEN\nINSERT (id,\n        col)\nVALUES (s.id, s.col);",
+            "MERGE INTO target t\nUSING SOURCE s\n    ON t.id = s.id\nWHEN MATCHED THEN\n    UPDATE\n    SET col = s.col\nWHEN NOT MATCHED THEN\n    INSERT (id, col)\n    VALUES (s.id, s.col);",
         ),
     ],
 )
@@ -24,3 +24,15 @@ def test_format_sql(sql, expected):
 def test_format_invalid_dialect():
     with pytest.raises(NotImplementedError):
         format_sql("SELECT 1", dialect="invalid")
+
+
+def test_format_case_options():
+    sql = "select id from users"
+    assert (
+        format_sql(sql, keyword_case="lower")
+        == "select id\nfrom users;"
+    )
+    assert (
+        format_sql(sql, keyword_case="upper", identifier_case="upper")
+        == "SELECT ID\nFROM USERS;"
+    )


### PR DESCRIPTION
## Summary
- fix MERGE statement formatting with custom `_format_merge`
- add options to control keyword and identifier casing
- expose case flags in CLI and document in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b4aed4cacc832f89225c6d3f780c22